### PR TITLE
Use ALTERANT_HOME

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 
@@ -60,7 +61,7 @@ func WriteToFile(cfg *config.Config) error {
 		return err
 	}
 
-	err = ioutil.WriteFile("/tmp/db.yaml", d, 0644)
+	err = ioutil.WriteFile(os.Getenv("ALTERANT_HOME")+"/db.yaml", d, 0644)
 	if err != nil {
 		return err
 	}
@@ -69,7 +70,7 @@ func WriteToFile(cfg *config.Config) error {
 }
 
 func ReadCache() (*Cache, error) {
-	bytes, err := ioutil.ReadFile("/tmp/db.yaml")
+	bytes, err := ioutil.ReadFile(os.Getenv("ALTERANT_HOME") + "/db.yaml")
 	if err != nil {
 		return nil, err
 	}

--- a/encrypter/default.go
+++ b/encrypter/default.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	defaultPublicKeyOutput  = os.Getenv("HOME") + "/.alterant/pubring.gpg"
-	defaultPrivateKeyOutput = os.Getenv("HOME") + "/.alterant/secring.gpg"
+	defaultPrivateKeyOutput = os.Getenv("ALTERANT_HOME") + "/private.asc"
+	defaultPublicKeyOutput  = os.Getenv("ALTERANT_HOME") + "/public.asc"
 )
 
 // DefaultEncryption is a basic encryption handler and is the default

--- a/main.go
+++ b/main.go
@@ -25,10 +25,11 @@ import (
 var version string
 
 func main() {
-	alterantDir := os.Getenv("HOME") + "/.alterant"
+	alterantHome := os.Getenv("HOME") + "/.alterant"
+	os.Setenv("ALTERANT_HOME", alterantHome)
 
-	if _, err := os.Stat(alterantDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(alterantDir, 0700); err != nil {
+	if _, err := os.Stat(alterantHome); os.IsNotExist(err) {
+		if err := os.MkdirAll(alterantHome, 0700); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -44,12 +45,12 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "private",
-			Value: os.Getenv("HOME") + "/.alterant/secring.gpg",
+			Value: os.Getenv("ALTERANT_HOME") + "/private.asc",
 			Usage: "OpenPGP ASCII armored private key",
 		},
 		cli.StringFlag{
 			Name:  "public",
-			Value: os.Getenv("HOME") + "/.alterant/pubring.gpg",
+			Value: os.Getenv("ALTERANT_HOME") + "/public.asc",
 			Usage: "OpenPGP ASCII armored public key",
 		},
 		cli.BoolFlag{
@@ -90,12 +91,12 @@ func main() {
 
 				url := c.Args()[0]
 				for _, requestedMachine := range c.Args().Tail() {
-					err := repo.CloneToAlterantDir(url, requestedMachine, alterantDir)
+					err := repo.CloneToAlterantDir(url, requestedMachine)
 					if err != nil {
 						log.Fatal(err)
 					}
 
-					err = os.Chdir(path.Join(alterantDir, requestedMachine))
+					err = os.Chdir(path.Join(alterantHome, requestedMachine))
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -144,7 +145,7 @@ func main() {
 				}
 
 				for _, requestedMachine := range c.Args() {
-					err := os.Chdir(path.Join(alterantDir, requestedMachine))
+					err := os.Chdir(path.Join(alterantHome, requestedMachine))
 					if err != nil {
 						log.Fatal(err)
 					}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -205,8 +205,8 @@ func CurrentMachine() (machine string, err error) {
 }
 
 // CloneToAlterantDir clones the requested machine to ~/.alterant
-func CloneToAlterantDir(url string, machine string, alterantDir string) error {
-	repoPath := path.Join(alterantDir, machine)
+func CloneToAlterantDir(url string, machine string) error {
+	repoPath := path.Join(os.Getenv("ALTERANT_HOME"), machine)
 	_, err := git.Clone(url, repoPath, &git.CloneOptions{CheckoutBranch: machine})
 	if err != nil {
 		return err


### PR DESCRIPTION
ALTERANT_HOME is now exported and available to the environment.
Additionally the names of the keys used for encryption/decryption are
now 'public.asc' and 'private.asc' to better communicate that they are
ASCII armored keys.